### PR TITLE
implement message bundle feature (#28)

### DIFF
--- a/scripts/adapters/duplicateDetector.js
+++ b/scripts/adapters/duplicateDetector.js
@@ -1,4 +1,5 @@
 const frontMatterCodec = require('./frontMatterCodec');
+const { extractSourceUrls } = require('../core/sourceUrls');
 
 // Adapter encapsulating duplicate detection logic against the inbox repository.
 
@@ -22,8 +23,9 @@ function findOriginalBySourceUrl(url, { fileSystem, directory }) {
     const filePath = fileSystem.join(targetDirectory, file);
     const content = fileSystem.readFile(filePath);
     const { frontMatter } = frontMatterCodec.parse(content);
+    const sourceUrls = extractSourceUrls(frontMatter);
 
-    if (frontMatter && frontMatter.source_url === url) {
+    if (sourceUrls.includes(url)) {
       return filePath;
     }
   }

--- a/scripts/core/sourceUrls.js
+++ b/scripts/core/sourceUrls.js
@@ -1,0 +1,54 @@
+function extractSourceUrls(frontMatter) {
+  if (!frontMatter || typeof frontMatter !== 'object') {
+    return [];
+  }
+
+  const urls = [];
+  addStringUrl(urls, frontMatter.source_url);
+  addArrayUrls(urls, frontMatter.source_urls);
+  addNestedUrls(urls, frontMatter.forwarded_messages);
+  addNestedUrls(urls, frontMatter.source_metadata);
+
+  return Array.from(new Set(urls));
+}
+
+function addArrayUrls(target, values) {
+  if (!Array.isArray(values)) {
+    return;
+  }
+
+  values.forEach((value) => {
+    addStringUrl(target, value);
+  });
+}
+
+function addNestedUrls(target, entries) {
+  if (!Array.isArray(entries)) {
+    return;
+  }
+
+  entries.forEach((entry) => {
+    if (!entry || typeof entry !== 'object') {
+      return;
+    }
+
+    addStringUrl(target, entry.source_url);
+  });
+}
+
+function addStringUrl(target, value) {
+  if (typeof value !== 'string') {
+    return;
+  }
+
+  const normalized = value.trim();
+  if (normalized === '') {
+    return;
+  }
+
+  target.push(normalized);
+}
+
+module.exports = {
+  extractSourceUrls,
+};

--- a/scripts/core/telegramMessageBundler.js
+++ b/scripts/core/telegramMessageBundler.js
@@ -1,0 +1,282 @@
+const DEFAULT_BUNDLE_WINDOW_MS = 10 * 1000;
+
+function buildMessageBundles(
+  entries,
+  { bundleWindowMs = DEFAULT_BUNDLE_WINDOW_MS, nowMs = () => Date.now() } = {},
+) {
+  const normalizedEntries = Array.isArray(entries) ? entries : [];
+  const bundles = [];
+  let activeBundle = null;
+  let previousTimestampMs = null;
+
+  normalizedEntries.forEach((entry) => {
+    if (!isEntry(entry)) {
+      if (activeBundle) {
+        bundles.push(finalizeBundle(activeBundle, 'ambiguous', null, bundleWindowMs, nowMs));
+        activeBundle = null;
+      }
+      bundles.push(createAmbiguousBundle({}, 'invalid_entry', nowMs));
+      return;
+    }
+
+    const entryType = normalizeEntryType(entry.type);
+    const entryTimestampMs = toTimestampMs(entry.timestampMs);
+    const hasTimestamp = entryTimestampMs !== null;
+
+    if (entryType !== 'note' && hasTimestamp && previousTimestampMs !== null && entryTimestampMs <= previousTimestampMs) {
+      if (activeBundle) {
+        bundles.push(finalizeBundle(activeBundle, 'ambiguous', entryTimestampMs, bundleWindowMs, nowMs));
+        activeBundle = null;
+      }
+      bundles.push(createAmbiguousBundle(entry, 'timestamp_conflict', nowMs));
+      return;
+    }
+
+    if (entryType === 'ambiguous' || (entryType !== 'note' && !hasTimestamp)) {
+      if (activeBundle) {
+        bundles.push(finalizeBundle(activeBundle, 'ambiguous', entryTimestampMs, bundleWindowMs, nowMs));
+        activeBundle = null;
+      }
+      bundles.push(createAmbiguousBundle(entry, entryType === 'ambiguous' ? 'ambiguous_classification' : 'missing_timestamp', nowMs));
+      return;
+    }
+
+    if (entryType === 'note') {
+      if (activeBundle) {
+        bundles.push(finalizeBundle(activeBundle, 'note', entryTimestampMs, bundleWindowMs, nowMs));
+      }
+      activeBundle = createNoteBundle(entry, entryTimestampMs, nowMs);
+      previousTimestampMs = updatePreviousTimestamp(previousTimestampMs, entryTimestampMs);
+      return;
+    }
+
+    if (entryType === 'forward') {
+      const forwardTimestampMs = entryTimestampMs;
+
+      if (activeBundle && isWithinWindow(activeBundle.noteTimestampMs, forwardTimestampMs, bundleWindowMs)) {
+        appendForwardToBundle(activeBundle, entry, forwardTimestampMs);
+        previousTimestampMs = updatePreviousTimestamp(previousTimestampMs, forwardTimestampMs);
+        return;
+      }
+
+      if (activeBundle) {
+        bundles.push(finalizeBundle(activeBundle, 'timeout', forwardTimestampMs, bundleWindowMs, nowMs));
+        activeBundle = null;
+      }
+
+      bundles.push(createAmbiguousBundle(entry, 'orphan_forward', nowMs));
+      previousTimestampMs = updatePreviousTimestamp(previousTimestampMs, forwardTimestampMs);
+      return;
+    }
+
+    if (entryType === 'other') {
+      if (activeBundle) {
+        bundles.push(finalizeBundle(activeBundle, 'other', entryTimestampMs, bundleWindowMs, nowMs));
+        activeBundle = null;
+      }
+      previousTimestampMs = updatePreviousTimestamp(previousTimestampMs, entryTimestampMs);
+    }
+  });
+
+  if (activeBundle) {
+    bundles.push(finalizeBundle(activeBundle, 'end_of_stream', null, bundleWindowMs, nowMs));
+  }
+
+  return bundles;
+}
+
+function appendForwardToBundle(bundle, entry, timestampMs) {
+  const forwardMetadata = entry.forwardMetadata && typeof entry.forwardMetadata === 'object'
+    ? entry.forwardMetadata
+    : {};
+  const sourceInfo = typeof forwardMetadata.sourceInfo === 'string' && forwardMetadata.sourceInfo.trim() !== ''
+    ? forwardMetadata.sourceInfo
+    : 'Unknown';
+  const sourceUrl = typeof forwardMetadata.sourceUrl === 'string' ? forwardMetadata.sourceUrl : '';
+  const forwardProtected = Boolean(forwardMetadata.forwardProtected);
+  const forwardDate = typeof forwardMetadata.forwardDate === 'string' ? forwardMetadata.forwardDate : '';
+  const hasMedia = Boolean(forwardMetadata.hasMedia);
+  const mediaType = typeof forwardMetadata.mediaType === 'string' ? forwardMetadata.mediaType : 'none';
+  const messageId = entry.messageId;
+  const forwardTimestamp = new Date(timestampMs).toISOString();
+
+  bundle.messageIds.push(messageId);
+  bundle.forwardedMessages.push({
+    message_id: messageId,
+    timestamp: forwardTimestamp,
+    content: typeof entry.content === 'string' ? entry.content : '',
+    source_info: sourceInfo,
+    source_url: sourceUrl,
+    forward_date: forwardDate,
+    has_media: hasMedia,
+    media_type: mediaType,
+    forward_protected: forwardProtected,
+  });
+  bundle.sourceMetadata.push({
+    message_id: messageId,
+    message_type: 'forward',
+    source_info: sourceInfo,
+    source_url: sourceUrl,
+    forward_protected: forwardProtected,
+  });
+  bundle.lastMessageTimestampMs = timestampMs;
+}
+
+function createAmbiguousBundle(entry, reason, nowMs) {
+  const entryType = normalizeEntryType(entry.type);
+  const safeTimestampMs = toTimestampMs(entry.timestampMs) ?? nowMs();
+  const safeMessageId = entry.messageId !== undefined ? entry.messageId : null;
+  const noteText = entryType === 'note' && typeof entry.noteText === 'string' ? entry.noteText : '';
+  const messageIds = safeMessageId !== null ? [safeMessageId] : [];
+  const sourceMetadata = [];
+  const forwardedMessages = [];
+
+  if (entryType === 'note' && safeMessageId !== null) {
+    sourceMetadata.push({
+      message_id: safeMessageId,
+      message_type: 'note',
+      source_info: 'direct_message',
+      source_url: '',
+      forward_protected: false,
+    });
+  }
+
+  if (entryType === 'forward' && safeMessageId !== null) {
+    const forwardMetadata = entry.forwardMetadata && typeof entry.forwardMetadata === 'object'
+      ? entry.forwardMetadata
+      : {};
+    const sourceInfo = typeof forwardMetadata.sourceInfo === 'string' && forwardMetadata.sourceInfo.trim() !== ''
+      ? forwardMetadata.sourceInfo
+      : 'Unknown';
+    const sourceUrl = typeof forwardMetadata.sourceUrl === 'string' ? forwardMetadata.sourceUrl : '';
+    const forwardProtected = Boolean(forwardMetadata.forwardProtected);
+    const forwardDate = typeof forwardMetadata.forwardDate === 'string' ? forwardMetadata.forwardDate : '';
+    const hasMedia = Boolean(forwardMetadata.hasMedia);
+    const mediaType = typeof forwardMetadata.mediaType === 'string' ? forwardMetadata.mediaType : 'none';
+    const isoTimestamp = new Date(safeTimestampMs).toISOString();
+
+    forwardedMessages.push({
+      message_id: safeMessageId,
+      timestamp: isoTimestamp,
+      content: typeof entry.content === 'string' ? entry.content : '',
+      source_info: sourceInfo,
+      source_url: sourceUrl,
+      forward_date: forwardDate,
+      has_media: hasMedia,
+      media_type: mediaType,
+      forward_protected: forwardProtected,
+    });
+    sourceMetadata.push({
+      message_id: safeMessageId,
+      message_type: 'forward',
+      source_info: sourceInfo,
+      source_url: sourceUrl,
+      forward_protected: forwardProtected,
+    });
+  }
+
+  return {
+    note_text: noteText,
+    forwarded_messages: forwardedMessages,
+    bundle_start_at: new Date(safeTimestampMs).toISOString(),
+    bundle_end_at: new Date(safeTimestampMs).toISOString(),
+    message_ids: messageIds,
+    source_metadata: sourceMetadata,
+    status: 'ambiguous',
+    ambiguity_reason: reason,
+  };
+}
+
+function createNoteBundle(entry, timestampMs, nowMs) {
+  const noteTimestampMs = timestampMs ?? nowMs();
+  const noteMessageId = entry.messageId;
+  const noteText = typeof entry.noteText === 'string' ? entry.noteText : '';
+
+  return {
+    messageIds: [noteMessageId],
+    noteMessageId,
+    noteText,
+    noteTimestampMs,
+    sourceMetadata: [
+      {
+        message_id: noteMessageId,
+        message_type: 'note',
+        source_info: 'direct_message',
+        source_url: '',
+        forward_protected: false,
+      },
+    ],
+    status: 'normal',
+    forwardedMessages: [],
+    lastMessageTimestampMs: noteTimestampMs,
+  };
+}
+
+function finalizeBundle(bundle, reason, triggerTimestampMs, bundleWindowMs, nowMs) {
+  const safeReason = typeof reason === 'string' ? reason : 'end_of_stream';
+  const endTimestampMs = resolveEndTimestamp(bundle, safeReason, triggerTimestampMs, bundleWindowMs, nowMs);
+
+  return {
+    note_text: bundle.noteText,
+    forwarded_messages: bundle.forwardedMessages,
+    bundle_start_at: new Date(bundle.noteTimestampMs).toISOString(),
+    bundle_end_at: new Date(endTimestampMs).toISOString(),
+    message_ids: bundle.messageIds,
+    source_metadata: bundle.sourceMetadata,
+    status: safeReason === 'ambiguous' ? 'ambiguous' : bundle.status,
+    ambiguity_reason: safeReason === 'ambiguous' ? 'sequencing_conflict' : undefined,
+  };
+}
+
+function resolveEndTimestamp(bundle, reason, triggerTimestampMs, bundleWindowMs, nowMs) {
+  if (reason === 'timeout') {
+    return bundle.noteTimestampMs + bundleWindowMs;
+  }
+
+  if (toTimestampMs(triggerTimestampMs) !== null) {
+    return triggerTimestampMs;
+  }
+
+  if (reason === 'end_of_stream' || reason === 'ambiguous') {
+    return toTimestampMs(bundle.lastMessageTimestampMs) ?? nowMs();
+  }
+
+  return toTimestampMs(bundle.lastMessageTimestampMs) ?? nowMs();
+}
+
+function isEntry(entry) {
+  return entry && typeof entry === 'object' && entry.messageId !== undefined;
+}
+
+function isWithinWindow(noteTimestampMs, messageTimestampMs, bundleWindowMs) {
+  return messageTimestampMs >= noteTimestampMs && messageTimestampMs <= noteTimestampMs + bundleWindowMs;
+}
+
+function normalizeEntryType(type) {
+  if (type === 'note' || type === 'forward' || type === 'other' || type === 'ambiguous') {
+    return type;
+  }
+
+  return 'ambiguous';
+}
+
+function toTimestampMs(value) {
+  return Number.isFinite(value) ? value : null;
+}
+
+function updatePreviousTimestamp(previousTimestampMs, nextTimestampMs) {
+  if (toTimestampMs(nextTimestampMs) === null) {
+    return previousTimestampMs;
+  }
+
+  if (toTimestampMs(previousTimestampMs) === null) {
+    return nextTimestampMs;
+  }
+
+  return Math.max(previousTimestampMs, nextTimestampMs);
+}
+
+module.exports = {
+  DEFAULT_BUNDLE_WINDOW_MS,
+  buildMessageBundles,
+};

--- a/scripts/poll-telegram.js
+++ b/scripts/poll-telegram.js
@@ -1,6 +1,8 @@
 const fs = require("fs");
 const path = require("path");
+const frontMatterCodec = require("./adapters/frontMatterCodec");
 const formatTimestamp = require("./adapters/formatTimestamp");
+const { buildMessageBundles } = require("./core/telegramMessageBundler");
 
 async function pollTelegram() {
   console.log("Starting Telegram polling...");
@@ -33,6 +35,7 @@ async function pollTelegram() {
     let processedCount = 0;
     let skippedCount = 0;
     let highestUpdateId = 0;
+    const bundleEntries = [];
 
     for (const update of updates) {
       // Track highest update ID for proper offset handling
@@ -61,24 +64,21 @@ async function pollTelegram() {
         continue;
       }
 
-      if (isForwardedMessage(message)) {
-        if (process.env.DEBUG === "true") {
-          console.log(
-            "Full forwarded message object:",
-            JSON.stringify(message, null, 2),
-          );
-        }
-        await processForwardedMessage(message);
-        processedCount++;
-      } else if (hasContent(message)) {
-        await processRegularMessage(message);
-        processedCount++;
-      } else {
-        console.log(
-          `Skipping message ${message.message_id} - no processable content`,
-        );
-        skippedCount++;
-      }
+      bundleEntries.push(toBundleEntry(message));
+    }
+
+    const bundles = buildMessageBundles(bundleEntries);
+    const bundledMessageIds = collectBundledMessageIds(bundles);
+
+    for (const bundle of bundles) {
+      writeBundleToInbox(bundle);
+      processedCount++;
+    }
+
+    skippedCount += bundleEntries.filter((entry) => !bundledMessageIds.has(entry.messageId)).length;
+
+    if (process.env.DEBUG === "true") {
+      console.log(`Created ${bundles.length} message bundles`);
     }
 
     // Mark all messages as processed at once
@@ -87,7 +87,7 @@ async function pollTelegram() {
     }
 
     console.log(
-      `Processed ${processedCount} messages, skipped ${skippedCount} messages`,
+      `Processed ${processedCount} bundles, skipped ${skippedCount} messages`,
     );
   } catch (error) {
     console.error("Error polling Telegram:", error);
@@ -111,11 +111,92 @@ function isForwardedMessage(message) {
   );
 }
 
-// Check if message has any processable content
-function hasContent(message) {
+function toBundleEntry(message) {
+  const type = classifyMessage(message);
+  const timestampMs = extractMessageTimestampMs(message);
+  const messageId = message && message.message_id !== undefined ? message.message_id : null;
+
+  if (type === "forward") {
+    return {
+      type,
+      timestampMs,
+      messageId,
+      content: extractMessageContent(message),
+      forwardMetadata: {
+        ...extractForwardSourceMetadata(message),
+        forwardDate: message.forward_date ? new Date(message.forward_date * 1000).toISOString() : "",
+        hasMedia: hasMedia(message),
+        mediaType: getMediaType(message),
+      },
+    };
+  }
+
+  if (type === "note") {
+    return {
+      type,
+      timestampMs,
+      messageId,
+      noteText: extractMessageContent(message),
+    };
+  }
+
+  return {
+    type,
+    timestampMs,
+    messageId,
+  };
+}
+
+function classifyMessage(message) {
+  if (!message || typeof message !== "object" || message.message_id === undefined) {
+    return "ambiguous";
+  }
+
+  if (isForwardedMessage(message)) {
+    return "forward";
+  }
+
+  if (isNoteMessage(message)) {
+    return "note";
+  }
+
+  return "other";
+}
+
+function isNoteMessage(message) {
+  if (!message || typeof message.text !== "string" || message.text.trim() === "") {
+    return false;
+  }
+
+  if (!message.from || typeof message.from !== "object") {
+    return false;
+  }
+
+  if (message.caption) {
+    return false;
+  }
+
+  if (message.from.is_bot === true) {
+    return false;
+  }
+
+  if (message.sender_chat) {
+    return false;
+  }
+
+  if (message.chat && message.chat.type === "channel") {
+    return false;
+  }
+
+  if (isServiceMessage(message) || hasNonTextPayload(message)) {
+    return false;
+  }
+
+  return true;
+}
+
+function hasNonTextPayload(message) {
   return !!(
-    message.text ||
-    message.caption ||
     message.photo ||
     message.video ||
     message.document ||
@@ -133,22 +214,44 @@ function hasContent(message) {
   );
 }
 
-async function processForwardedMessage(message) {
-  const timestamp = new Date();
-  const filename = formatTimestamp(timestamp) + ".md";
-  const filepath = path.join("_inbox", filename);
+function isServiceMessage(message) {
+  return !!(
+    message.new_chat_members ||
+    message.left_chat_member ||
+    message.new_chat_title ||
+    message.new_chat_photo ||
+    message.delete_chat_photo ||
+    message.group_chat_created ||
+    message.supergroup_chat_created ||
+    message.channel_chat_created ||
+    message.message_auto_delete_timer_changed ||
+    message.migrate_to_chat_id ||
+    message.migrate_from_chat_id ||
+    message.pinned_message ||
+    message.invoice ||
+    message.successful_payment ||
+    message.user_shared ||
+    message.chat_shared ||
+    message.forum_topic_created ||
+    message.forum_topic_closed ||
+    message.forum_topic_reopened ||
+    message.giveaway ||
+    message.giveaway_created ||
+    message.giveaway_completed
+  );
+}
 
-  if (!fs.existsSync("_inbox")) {
-    fs.mkdirSync("_inbox", { recursive: true });
-  }
+function extractMessageTimestampMs(message) {
+  const unixSeconds = Number(message && message.date);
+  return Number.isFinite(unixSeconds) ? unixSeconds * 1000 : null;
+}
 
+function extractForwardSourceMetadata(message) {
   let sourceInfo = "Unknown";
   let sourceUrl = "";
-  let isForwardProtected = false;
+  let forwardProtected = false;
 
-  // Enhanced source info extraction - handles all forward types
   if (message.forward_origin) {
-    // New API structure - more reliable
     switch (message.forward_origin.type) {
       case "user":
         const user = message.forward_origin.sender_user;
@@ -171,81 +274,173 @@ async function processForwardedMessage(message) {
         break;
       case "hidden_user":
         sourceInfo = message.forward_origin.sender_user_name || "Hidden User";
-        isForwardProtected = true;
+        forwardProtected = true;
         break;
     }
-  } else {
-    // Fallback to legacy fields
-    if (message.forward_from) {
-      const user = message.forward_from;
-      sourceInfo = user.username
-        ? `@${user.username}`
-        : `${user.first_name || "Unknown"} ${user.last_name || ""}`.trim();
-    } else if (message.forward_from_chat) {
-      const chat = message.forward_from_chat;
-      sourceInfo = chat.title || `@${chat.username}` || "Unknown Chat";
-
-      // Try to build URL for public channels
-      if (chat.username && message.forward_from_message_id) {
-        sourceUrl = `https://t.me/${chat.username}/${message.forward_from_message_id}`;
-      }
-    } else if (message.forward_sender_name) {
-      sourceInfo = message.forward_sender_name;
-      isForwardProtected = true;
+  } else if (message.forward_from) {
+    const user = message.forward_from;
+    sourceInfo = user.username
+      ? `@${user.username}`
+      : `${user.first_name || "Unknown"} ${user.last_name || ""}`.trim();
+  } else if (message.forward_from_chat) {
+    const chat = message.forward_from_chat;
+    sourceInfo = chat.title || `@${chat.username}` || "Unknown Chat";
+    if (chat.username && message.forward_from_message_id) {
+      sourceUrl = `https://t.me/${chat.username}/${message.forward_from_message_id}`;
     }
+  } else if (message.forward_sender_name) {
+    sourceInfo = message.forward_sender_name;
+    forwardProtected = true;
   }
 
-  // Extract comprehensive message content
-  const content = extractMessageContent(message);
-
-  const frontMatter = `---
-raw_message: true
-message_id: ${message.message_id}
-timestamp: "${timestamp.toISOString()}"
-source_info: "${sourceInfo.replace(/"/g, '\\"')}"
-source_url: "${sourceUrl}"
-forward_date: "${message.forward_date ? new Date(message.forward_date * 1000).toISOString() : ""}"
-has_media: ${hasMedia(message)}
-media_type: "${getMediaType(message)}"
-forward_protected: ${isForwardProtected}
----`;
-
-  const fullContent = `${frontMatter}\n\n${content}`;
-
-  fs.writeFileSync(filepath, fullContent, "utf8");
-  console.log(`Created forwarded message file: ${filepath}`);
-
-  if (process.env.DEBUG === "true") {
-    console.log("File content preview:", fullContent.substring(0, 500) + "...");
-  }
+  return {
+    sourceInfo,
+    sourceUrl,
+    forwardProtected,
+  };
 }
 
-async function processRegularMessage(message) {
-  const timestamp = new Date();
-  const filename = formatTimestamp(timestamp) + "_regular.md";
-  const filepath = path.join("_inbox", filename);
-
+function writeBundleToInbox(bundle) {
   if (!fs.existsSync("_inbox")) {
     fs.mkdirSync("_inbox", { recursive: true });
   }
 
-  const content = extractMessageContent(message);
+  const bundleStartAt = toIsoString(bundle.bundle_start_at);
+  const primaryMessageId = Array.isArray(bundle.message_ids) && bundle.message_ids.length > 0
+    ? bundle.message_ids[0]
+    : Date.now().toString(36);
+  const bundleTypeSuffix = bundle.status === "ambiguous" ? "ambiguous" : "bundle";
+  const filename = `${formatTimestamp(bundleStartAt)}-${primaryMessageId}-${bundleTypeSuffix}.md`;
+  const filepath = path.join("_inbox", filename);
+  const forwardedMessages = Array.isArray(bundle.forwarded_messages) ? bundle.forwarded_messages : [];
+  const sourceMetadata = Array.isArray(bundle.source_metadata) ? bundle.source_metadata : [];
+  const sourceUrls = extractBundleSourceUrls(bundle);
 
-  const frontMatter = `---
-raw_message: true
-message_id: ${message.message_id}
-timestamp: "${timestamp.toISOString()}"
-source_info: "direct_message"
-source_url: ""
-has_media: ${hasMedia(message)}
-media_type: "${getMediaType(message)}"
-forward_protected: false
----`;
+  const content = frontMatterCodec.stringify({
+    frontMatter: {
+      raw_message: true,
+      message_bundle: true,
+      message_id: primaryMessageId,
+      message_ids: Array.isArray(bundle.message_ids) ? bundle.message_ids : [],
+      timestamp: bundleStartAt,
+      bundle_start_at: bundleStartAt,
+      bundle_end_at: toIsoString(bundle.bundle_end_at),
+      note_text: typeof bundle.note_text === "string" ? bundle.note_text : "",
+      forwarded_messages: forwardedMessages,
+      source_metadata: sourceMetadata,
+      source_info: "bundle",
+      source_url: sourceUrls[0] || "",
+      source_urls: sourceUrls,
+      has_media: forwardedMessages.some((message) => Boolean(message.has_media)),
+      media_type: resolveBundleMediaType(forwardedMessages),
+      forward_protected: sourceMetadata.some((metadata) => Boolean(metadata.forward_protected)),
+      bundle_status: bundle.status,
+      ambiguity_reason: bundle.ambiguity_reason || "",
+    },
+    bodyContent: createBundleBody(bundle),
+  });
 
-  const fullContent = `${frontMatter}\n\n${content}`;
+  fs.writeFileSync(filepath, content, "utf8");
+  console.log(`Created bundle file: ${filepath}`);
+}
 
-  fs.writeFileSync(filepath, fullContent, "utf8");
-  console.log(`Created regular message file: ${filepath}`);
+function extractBundleSourceUrls(bundle) {
+  const urls = [];
+  const forwardedMessages = Array.isArray(bundle.forwarded_messages) ? bundle.forwarded_messages : [];
+  const sourceMetadata = Array.isArray(bundle.source_metadata) ? bundle.source_metadata : [];
+
+  addSourceUrls(urls, forwardedMessages);
+  addSourceUrls(urls, sourceMetadata);
+
+  return Array.from(new Set(urls));
+}
+
+function addSourceUrls(target, entries) {
+  entries.forEach((entry) => {
+    if (!entry || typeof entry !== "object") {
+      return;
+    }
+
+    const sourceUrl = typeof entry.source_url === "string" ? entry.source_url.trim() : "";
+    if (sourceUrl === "") {
+      return;
+    }
+
+    target.push(sourceUrl);
+  });
+}
+
+function collectBundledMessageIds(bundles) {
+  const bundledIds = new Set();
+
+  bundles.forEach((bundle) => {
+    if (!Array.isArray(bundle.message_ids)) {
+      return;
+    }
+
+    bundle.message_ids.forEach((messageId) => {
+      bundledIds.add(messageId);
+    });
+  });
+
+  return bundledIds;
+}
+
+function createBundleBody(bundle) {
+  const sections = [];
+  const noteText = typeof bundle.note_text === "string" ? bundle.note_text.trim() : "";
+  const forwardedMessages = Array.isArray(bundle.forwarded_messages) ? bundle.forwarded_messages : [];
+
+  if (noteText !== "") {
+    sections.push(noteText);
+  }
+
+  if (forwardedMessages.length > 0) {
+    sections.push("Forwarded Messages");
+    forwardedMessages.forEach((forwardedMessage, index) => {
+      const title = `Forward ${index + 1} (message_id: ${forwardedMessage.message_id})`;
+      const sourceInfo = `Source: ${forwardedMessage.source_info || "Unknown"}`;
+      const content = typeof forwardedMessage.content === "string" && forwardedMessage.content.trim() !== ""
+        ? forwardedMessage.content
+        : "[No extractable content]";
+      sections.push(`${title}\n${sourceInfo}\n\n${content}`);
+    });
+  }
+
+  if (sections.length === 0) {
+    return "[Empty bundle]";
+  }
+
+  return sections.join("\n\n");
+}
+
+function resolveBundleMediaType(forwardedMessages) {
+  const mediaTypes = Array.from(
+    new Set(
+      forwardedMessages
+        .map((forwardedMessage) => forwardedMessage.media_type)
+        .filter((mediaType) => mediaType && mediaType !== "none"),
+    ),
+  );
+
+  if (mediaTypes.length === 0) {
+    return "none";
+  }
+
+  if (mediaTypes.length === 1) {
+    return mediaTypes[0];
+  }
+
+  return "mixed";
+}
+
+function toIsoString(value) {
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) {
+    return new Date().toISOString();
+  }
+
+  return date.toISOString();
 }
 
 // Enhanced content extraction - handles all message types

--- a/scripts/process-messages.js
+++ b/scripts/process-messages.js
@@ -5,6 +5,7 @@ const formatTimestamp = require('./adapters/formatTimestamp');
 const frontMatterCodec = require('./adapters/frontMatterCodec');
 const logger = require('./adapters/consoleLogger');
 const messageProcessor = require('./core/messageProcessor');
+const { extractSourceUrls } = require('./core/sourceUrls');
 
 async function processMessages() {
   logger.info('Starting message processing...');
@@ -80,8 +81,8 @@ async function processFile(inboxPath) {
     logger.info(`Body content preview: ${bodyContent.substring(0, 200)}...`);
   }
 
-  const sourceUrl = frontMatter.source_url;
-  if (sourceUrl && sourceUrl !== '') {
+  const sourceUrls = extractSourceUrls(frontMatter);
+  for (const sourceUrl of sourceUrls) {
     const originalFilePath = duplicateDetector.findOriginalBySourceUrl(sourceUrl, {
       fileSystem,
       directory: 'inbox',
@@ -139,6 +140,11 @@ async function processFile(inboxPath) {
     { frontMatter, bodyContent },
     aiResults
   );
+  const preservedMetadata = extractPreservedMetadata(frontMatter, sourceUrls);
+  const finalFrontMatter = {
+    ...enrichedFrontMatter,
+    ...preservedMetadata,
+  };
   
   // Generate new filename with AI title and timestamp
   const timestamp = new Date(frontMatter.timestamp || Date.now());
@@ -147,7 +153,7 @@ async function processFile(inboxPath) {
   
   // Create new content
   const newContent = frontMatterCodec.stringify({
-    frontMatter: enrichedFrontMatter,
+    frontMatter: finalFrontMatter,
     bodyContent,
   });
   
@@ -164,6 +170,39 @@ async function processFile(inboxPath) {
   fileSystem.unlink(inboxPath);
   logger.info(`Deleted original file: ${inboxPath}`);
   return 'processed';
+}
+
+function extractPreservedMetadata(frontMatter, sourceUrls) {
+  if (!frontMatter || typeof frontMatter !== 'object') {
+    return {};
+  }
+
+  const preservedMetadata = {};
+  const bundleKeys = [
+    'message_bundle',
+    'message_ids',
+    'bundle_start_at',
+    'bundle_end_at',
+    'note_text',
+    'forwarded_messages',
+    'source_metadata',
+    'bundle_status',
+    'ambiguity_reason',
+    'source_urls',
+  ];
+
+  bundleKeys.forEach((key) => {
+    if (frontMatter[key] !== undefined) {
+      preservedMetadata[key] = frontMatter[key];
+    }
+  });
+
+  const primarySourceUrl = sourceUrls.length > 0 ? sourceUrls[0] : null;
+  if (primarySourceUrl) {
+    preservedMetadata.source_url = primarySourceUrl;
+  }
+
+  return preservedMetadata;
 }
 
 // Run the processing

--- a/test/poll-telegram.test.js
+++ b/test/poll-telegram.test.js
@@ -1,0 +1,367 @@
+const path = require('path');
+const frontMatterCodec = require('../scripts/adapters/frontMatterCodec');
+const { setupTestEnvironment } = require('./harness/setupTestEnvironment');
+
+describe('poll-telegram script', () => {
+  let testEnv;
+
+  beforeEach(() => {
+    testEnv = setupTestEnvironment();
+    process.env.BOT_TOKEN = 'test-token';
+    process.env.CHAT_ID = '12345';
+    process.env.DEBUG = 'false';
+    jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
+    });
+  });
+
+  afterEach(() => {
+    if (testEnv && typeof testEnv.restore === 'function') {
+      testEnv.restore();
+    }
+
+    delete process.env.BOT_TOKEN;
+    delete process.env.CHAT_ID;
+    delete process.env.DEBUG;
+    delete global.fetch;
+    jest.restoreAllMocks();
+  });
+
+  test('creates one normal bundle file for note followed by forwards in window', async () => {
+    const updates = [
+      makeUpdate(1, makeNoteMessage(1001, 1700000000, 'Bundled note text')),
+      makeUpdate(2, makeForwardMessage(1002, 1700000005, 'Forward one', 'source-a', 321)),
+      makeUpdate(3, makeForwardMessage(1003, 1700000009, 'Forward two', 'source-b', 654)),
+    ];
+    mockTelegramFetch(updates);
+
+    const { pollTelegram } = require('../scripts/poll-telegram');
+    await pollTelegram();
+
+    const { fs } = testEnv;
+    const bundles = readInboxBundles(fs);
+
+    expect(bundles).toHaveLength(1);
+    expect(bundles[0].frontMatter).toMatchObject({
+      message_bundle: true,
+      message_ids: [1001, 1002, 1003],
+      note_text: 'Bundled note text',
+      bundle_status: 'normal',
+      source_url: 'https://t.me/source-a/321',
+      source_urls: ['https://t.me/source-a/321', 'https://t.me/source-b/654'],
+    });
+    expect(bundles[0].frontMatter.forwarded_messages).toHaveLength(2);
+    expect(bundles[0].bodyContent).toContain('Bundled note text');
+    expect(bundles[0].bodyContent).toContain('Forward 1');
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(fetch.mock.calls[1][1].body)).toEqual({ offset: 4 });
+  });
+
+  test('terminates note-only bundle on other message', async () => {
+    const updates = [
+      makeUpdate(1, makeNoteMessage(2001, 1700000100, 'Note that should close on other')),
+      makeUpdate(2, makeOtherMessage(2002, 1700000107)),
+    ];
+    mockTelegramFetch(updates);
+
+    const { pollTelegram } = require('../scripts/poll-telegram');
+    await pollTelegram();
+
+    const { fs } = testEnv;
+    const bundles = readInboxBundles(fs);
+
+    expect(bundles).toHaveLength(1);
+    expect(bundles[0].frontMatter).toMatchObject({
+      message_bundle: true,
+      message_ids: [2001],
+      note_text: 'Note that should close on other',
+      bundle_status: 'normal',
+      bundle_end_at: '2023-11-14T22:15:07.000Z',
+    });
+    expect(bundles[0].frontMatter.forwarded_messages).toEqual([]);
+  });
+
+  test('emits normal plus ambiguous bundle when forward arrives after timeout window', async () => {
+    const updates = [
+      makeUpdate(1, makeNoteMessage(3001, 1700000200, 'Timed note')),
+      makeUpdate(2, makeForwardMessage(3002, 1700000211, 'Late forward', 'late-source', 999)),
+    ];
+    mockTelegramFetch(updates);
+
+    const { pollTelegram } = require('../scripts/poll-telegram');
+    await pollTelegram();
+
+    const { fs } = testEnv;
+    const bundles = readInboxBundles(fs);
+
+    expect(bundles).toHaveLength(2);
+    const normalBundle = bundles.find((bundle) => bundle.frontMatter.bundle_status === 'normal');
+    const ambiguousBundle = bundles.find((bundle) => bundle.frontMatter.bundle_status === 'ambiguous');
+
+    expect(normalBundle.frontMatter).toMatchObject({
+      message_ids: [3001],
+      note_text: 'Timed note',
+      bundle_end_at: '2023-11-14T22:16:50.000Z',
+    });
+    expect(ambiguousBundle.frontMatter).toMatchObject({
+      message_ids: [3002],
+      bundle_status: 'ambiguous',
+      ambiguity_reason: 'orphan_forward',
+      source_url: 'https://t.me/late-source/999',
+      source_urls: ['https://t.me/late-source/999'],
+    });
+  });
+
+  test('skips updates from non-target chats', async () => {
+    const updates = [
+      makeUpdate(1, {
+        ...makeNoteMessage(4001, 1700000300, 'Wrong chat note'),
+        chat: { id: 99999 },
+      }),
+    ];
+    mockTelegramFetch(updates);
+
+    const { pollTelegram } = require('../scripts/poll-telegram');
+    await pollTelegram();
+
+    const { fs } = testEnv;
+    expect(fs.readdirSync('/_inbox')).toHaveLength(0);
+    expect(JSON.parse(fetch.mock.calls[1][1].body)).toEqual({ offset: 2 });
+  });
+
+  test('skips media group follower entries', async () => {
+    const updates = [
+      makeUpdate(1, {
+        message_id: 5001,
+        date: 1700000400,
+        chat: { id: 12345 },
+        from: { id: 1, is_bot: false },
+        media_group_id: 'group-1',
+        photo: [{ file_id: 'p1' }],
+      }),
+    ];
+    mockTelegramFetch(updates);
+
+    const { pollTelegram } = require('../scripts/poll-telegram');
+    await pollTelegram();
+
+    const { fs } = testEnv;
+    expect(fs.readdirSync('/_inbox')).toHaveLength(0);
+  });
+
+  test('classifies channel-origin plain text as other, not note', async () => {
+    const updates = [
+      makeUpdate(1, {
+        message_id: 6001,
+        date: 1700000500,
+        chat: { id: 12345, type: 'channel' },
+        sender_chat: { id: 321, title: 'Channel Author' },
+        text: 'Channel post text',
+      }),
+    ];
+    mockTelegramFetch(updates);
+
+    const { pollTelegram } = require('../scripts/poll-telegram');
+    await pollTelegram();
+
+    const { fs } = testEnv;
+    expect(fs.readdirSync('/_inbox')).toHaveLength(0);
+  });
+
+  test('extracts source metadata from forward_origin variants', async () => {
+    const updates = [
+      makeUpdate(1, makeNoteMessage(7001, 1700000600, 'header note')),
+      makeUpdate(2, makeForwardOriginUserMessage(7002, 1700000601)),
+      makeUpdate(3, makeForwardOriginChatMessage(7003, 1700000602)),
+      makeUpdate(4, makeForwardOriginChannelMessage(7004, 1700000603)),
+      makeUpdate(5, makeForwardOriginHiddenUserMessage(7005, 1700000604)),
+    ];
+    mockTelegramFetch(updates);
+
+    const { pollTelegram } = require('../scripts/poll-telegram');
+    await pollTelegram();
+
+    const { fs } = testEnv;
+    const bundles = readInboxBundles(fs);
+
+    expect(bundles).toHaveLength(1);
+    const forwardedMessages = bundles[0].frontMatter.forwarded_messages;
+    expect(forwardedMessages.map((entry) => entry.source_info)).toEqual([
+      '@origin-user',
+      'Origin Chat',
+      'Origin Channel',
+      'Hidden Origin',
+    ]);
+    expect(forwardedMessages.find((entry) => entry.message_id === 7004)).toMatchObject({
+      source_url: 'https://t.me/origin-channel/1234',
+    });
+    expect(forwardedMessages.find((entry) => entry.message_id === 7005)).toMatchObject({
+      forward_protected: true,
+    });
+  });
+
+  test('marks both bundles ambiguous on timestamp conflict for forward ordering', async () => {
+    const updates = [
+      makeUpdate(1, makeNoteMessage(8001, 1700000700, 'note')),
+      makeUpdate(2, makeForwardMessage(8002, 1700000705, 'forward one', 'conflict-a', 1)),
+      makeUpdate(3, makeForwardMessage(8003, 1700000705, 'forward two', 'conflict-b', 2)),
+    ];
+    mockTelegramFetch(updates);
+
+    const { pollTelegram } = require('../scripts/poll-telegram');
+    await pollTelegram();
+
+    const { fs } = testEnv;
+    const bundles = readInboxBundles(fs);
+
+    expect(bundles).toHaveLength(2);
+    const firstBundle = bundles.find((bundle) => bundle.frontMatter.message_ids.includes(8001));
+    const secondBundle = bundles.find((bundle) => bundle.frontMatter.message_ids.includes(8003));
+
+    expect(firstBundle.frontMatter).toMatchObject({
+      bundle_status: 'ambiguous',
+      ambiguity_reason: 'sequencing_conflict',
+    });
+    expect(secondBundle.frontMatter).toMatchObject({
+      bundle_status: 'ambiguous',
+      ambiguity_reason: 'timestamp_conflict',
+    });
+  });
+});
+
+function mockTelegramFetch(updates) {
+  global.fetch = jest
+    .fn()
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ ok: true, result: updates }),
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ ok: true, result: [] }),
+    });
+}
+
+function readInboxBundles(fs) {
+  const files = fs.readdirSync('/_inbox').sort();
+  return files.map((file) => {
+    const content = fs.readFileSync(path.join('/_inbox', file), 'utf8');
+    return {
+      file,
+      ...frontMatterCodec.parse(content),
+    };
+  });
+}
+
+function makeUpdate(updateId, message) {
+  return {
+    update_id: updateId,
+    message,
+  };
+}
+
+function makeNoteMessage(messageId, unixSeconds, text) {
+  return {
+    message_id: messageId,
+    date: unixSeconds,
+    chat: { id: 12345 },
+    from: { id: 1, is_bot: false },
+    text,
+  };
+}
+
+function makeForwardMessage(messageId, unixSeconds, text, channelUsername, forwardMessageId) {
+  return {
+    message_id: messageId,
+    date: unixSeconds,
+    chat: { id: 12345 },
+    from: { id: 2, is_bot: false },
+    text,
+    forward_from_chat: {
+      title: `Channel ${channelUsername}`,
+      username: channelUsername,
+    },
+    forward_from_message_id: forwardMessageId,
+    forward_date: unixSeconds - 60,
+  };
+}
+
+function makeOtherMessage(messageId, unixSeconds) {
+  return {
+    message_id: messageId,
+    date: unixSeconds,
+    chat: { id: 12345 },
+    from: { id: 1, is_bot: false },
+    poll: {
+      question: 'Is this an other message?',
+      type: 'regular',
+      options: [
+        { text: 'yes', voter_count: 0 },
+      ],
+    },
+  };
+}
+
+function makeForwardOriginUserMessage(messageId, unixSeconds) {
+  return {
+    message_id: messageId,
+    date: unixSeconds,
+    chat: { id: 12345 },
+    from: { id: 2, is_bot: false },
+    text: 'forward origin user',
+    forward_origin: {
+      type: 'user',
+      sender_user: {
+        username: 'origin-user',
+      },
+    },
+  };
+}
+
+function makeForwardOriginChatMessage(messageId, unixSeconds) {
+  return {
+    message_id: messageId,
+    date: unixSeconds,
+    chat: { id: 12345 },
+    from: { id: 2, is_bot: false },
+    text: 'forward origin chat',
+    forward_origin: {
+      type: 'chat',
+      sender_chat: {
+        title: 'Origin Chat',
+      },
+    },
+  };
+}
+
+function makeForwardOriginChannelMessage(messageId, unixSeconds) {
+  return {
+    message_id: messageId,
+    date: unixSeconds,
+    chat: { id: 12345 },
+    from: { id: 2, is_bot: false },
+    text: 'forward origin channel',
+    forward_origin: {
+      type: 'channel',
+      message_id: 1234,
+      chat: {
+        title: 'Origin Channel',
+        username: 'origin-channel',
+      },
+    },
+  };
+}
+
+function makeForwardOriginHiddenUserMessage(messageId, unixSeconds) {
+  return {
+    message_id: messageId,
+    date: unixSeconds,
+    chat: { id: 12345 },
+    from: { id: 2, is_bot: false },
+    text: 'forward origin hidden user',
+    forward_origin: {
+      type: 'hidden_user',
+      sender_user_name: 'Hidden Origin',
+    },
+  };
+}

--- a/test/process-messages.test.js
+++ b/test/process-messages.test.js
@@ -254,6 +254,135 @@ describe('process-messages script (Characterization Test)', () => {
       });
       expect(duplicateTicket.bodyContent).toContain('Дубликат, см. оригинал');
     });
+
+    test('should detect duplicate from bundled forwarded source_url metadata', async () => {
+      const bundledMessage = frontMatterCodec.stringify({
+        frontMatter: {
+          raw_message: true,
+          message_bundle: true,
+          message_id: 1001,
+          message_ids: [1001, 1002],
+          timestamp: '2025-09-21T09:34:07.837Z',
+          bundle_start_at: '2025-09-21T09:34:07.837Z',
+          bundle_end_at: '2025-09-21T09:34:12.837Z',
+          note_text: 'Bundled note',
+          forwarded_messages: [
+            {
+              message_id: 1002,
+              source_url: 'http://example.com/bundled-source',
+            },
+          ],
+          source_metadata: [
+            {
+              message_id: 1002,
+              source_url: 'http://example.com/bundled-source',
+            },
+          ],
+          source_url: '',
+          source_urls: [],
+          bundle_status: 'normal',
+        },
+        bodyContent: 'Bundled note',
+      });
+
+      testEnv = createSingleFileEnv({
+        inboxFiles: {
+          'bundle.md': bundledMessage,
+        },
+      });
+      const { fs } = testEnv;
+
+      const originalFilename = 'original.md';
+      fs.writeFileSync(`/inbox/${originalFilename}`, [
+        '---',
+        'source_url: "http://example.com/bundled-source"',
+        '---',
+        '',
+        'Existing processed bundle',
+      ].join('\n'), 'utf8');
+
+      const aiModule = require('../scripts/services/ai.js');
+      aiModule.getAIEnrichment = mockAISuccess({ title: 'Unused', summary: 'Unused', tags: [] });
+
+      const scriptResult = await runScript();
+
+      expect(scriptResult.logs.join('\n')).toContain(
+        'Duplicate found for http://example.com/bundled-source. Original: inbox/original.md'
+      );
+      expect(aiModule.getAIEnrichment).not.toHaveBeenCalled();
+      expect(fs.readdirSync('/inbox').sort()).toEqual([DUPLICATE_TICKET_NAME, originalFilename]);
+      expect(fs.existsSync('/_inbox/bundle.md')).toBe(false);
+    });
+
+    test('should preserve bundle metadata fields after AI enrichment', async () => {
+      const bundledMessage = frontMatterCodec.stringify({
+        frontMatter: {
+          raw_message: true,
+          message_bundle: true,
+          message_id: 2001,
+          message_ids: [2001, 2002],
+          timestamp: '2025-09-21T09:34:07.837Z',
+          bundle_start_at: '2025-09-21T09:34:07.837Z',
+          bundle_end_at: '2025-09-21T09:34:09.837Z',
+          note_text: 'Bundled note',
+          forwarded_messages: [
+            {
+              message_id: 2002,
+              source_url: 'http://example.com/bundle-keep',
+              content: 'Forwarded entry',
+            },
+          ],
+          source_metadata: [
+            {
+              message_id: 2002,
+              source_url: 'http://example.com/bundle-keep',
+            },
+          ],
+          source_url: '',
+          source_urls: ['http://example.com/bundle-keep'],
+          bundle_status: 'normal',
+          ambiguity_reason: '',
+        },
+        bodyContent: 'Bundled note',
+      });
+
+      testEnv = createSingleFileEnv({
+        inboxFiles: {
+          'bundle.md': bundledMessage,
+        },
+      });
+      const { fs } = testEnv;
+
+      const aiModule = require('../scripts/services/ai.js');
+      aiModule.getAIEnrichment = mockAISuccess({
+        title: 'Bundle-AI-Title',
+        summary: 'Bundle summary',
+        tags: ['bundle', 'ai'],
+      });
+
+      const scriptResult = await runScript();
+
+      expect(scriptResult.errors).toHaveLength(0);
+      expect(fs.readdirSync('/inbox')).toEqual([buildFilename('Bundle-AI-Title')]);
+
+      const output = fs.readFileSync(path.join('/inbox', buildFilename('Bundle-AI-Title')), 'utf8');
+      const { frontMatter } = frontMatterCodec.parse(output);
+
+      expect(frontMatter).toMatchObject({
+        message_bundle: true,
+        message_ids: [2001, 2002],
+        bundle_start_at: '2025-09-21T09:34:07.837Z',
+        bundle_end_at: '2025-09-21T09:34:09.837Z',
+        note_text: 'Bundled note',
+        bundle_status: 'normal',
+        source_url: 'http://example.com/bundle-keep',
+        source_urls: ['http://example.com/bundle-keep'],
+        summary: 'Bundle summary',
+        tags: ['bundle', 'ai'],
+      });
+      expect(frontMatter.forwarded_messages).toHaveLength(1);
+      expect(frontMatter.source_metadata).toHaveLength(1);
+    });
   });
 
   describe('Scenario 2: two files', () => {

--- a/test/sourceUrls.test.js
+++ b/test/sourceUrls.test.js
@@ -1,0 +1,30 @@
+const { extractSourceUrls } = require('../scripts/core/sourceUrls');
+
+describe('sourceUrls.extractSourceUrls', () => {
+  test('returns unique non-empty URLs from all supported metadata fields', () => {
+    const sourceUrls = extractSourceUrls({
+      source_url: 'https://a.example',
+      source_urls: ['https://b.example', '', 'https://a.example'],
+      forwarded_messages: [
+        { source_url: 'https://c.example' },
+        { source_url: 'https://b.example' },
+      ],
+      source_metadata: [
+        { source_url: 'https://d.example' },
+      ],
+    });
+
+    expect(sourceUrls).toEqual([
+      'https://a.example',
+      'https://b.example',
+      'https://c.example',
+      'https://d.example',
+    ]);
+  });
+
+  test('returns empty list for invalid input', () => {
+    expect(extractSourceUrls(undefined)).toEqual([]);
+    expect(extractSourceUrls(null)).toEqual([]);
+    expect(extractSourceUrls('not-object')).toEqual([]);
+  });
+});

--- a/test/telegramMessageBundler.test.js
+++ b/test/telegramMessageBundler.test.js
@@ -1,0 +1,151 @@
+const {
+  buildMessageBundles,
+  DEFAULT_BUNDLE_WINDOW_MS,
+} = require('../scripts/core/telegramMessageBundler');
+
+const WINDOW_MS = DEFAULT_BUNDLE_WINDOW_MS;
+
+describe('telegramMessageBundler.buildMessageBundles', () => {
+  test('creates a normal bundle with note and forwards inside the 10 second window', () => {
+    const bundles = buildMessageBundles([
+      makeNote(101, 1000, 'User note'),
+      makeForward(201, 4000, 'Forwarded content'),
+      makeForward(202, 9000, 'Second forwarded content'),
+    ]);
+
+    expect(bundles).toHaveLength(1);
+    expect(bundles[0]).toMatchObject({
+      note_text: 'User note',
+      message_ids: [101, 201, 202],
+      status: 'normal',
+      forwarded_messages: [
+        expect.objectContaining({ message_id: 201, content: 'Forwarded content' }),
+        expect.objectContaining({ message_id: 202, content: 'Second forwarded content' }),
+      ],
+    });
+  });
+
+  test('preserves note-only bundle when no forward appears before stream end', () => {
+    const bundles = buildMessageBundles([makeNote(101, 1000, 'Note only')]);
+
+    expect(bundles).toHaveLength(1);
+    expect(bundles[0]).toEqual({
+      note_text: 'Note only',
+      forwarded_messages: [],
+      bundle_start_at: '1970-01-01T00:00:01.000Z',
+      bundle_end_at: '1970-01-01T00:00:01.000Z',
+      message_ids: [101],
+      source_metadata: [
+        {
+          message_id: 101,
+          message_type: 'note',
+          source_info: 'direct_message',
+          source_url: '',
+          forward_protected: false,
+        },
+      ],
+      status: 'normal',
+      ambiguity_reason: undefined,
+    });
+  });
+
+  test('terminates active note bundle on other message', () => {
+    const bundles = buildMessageBundles([
+      makeNote(101, 1000, 'First note'),
+      makeOther(301, 7000),
+    ]);
+
+    expect(bundles).toHaveLength(1);
+    expect(bundles[0].bundle_end_at).toBe('1970-01-01T00:00:07.000Z');
+  });
+
+  test('marks orphan forward as ambiguous when it arrives after note window', () => {
+    const bundles = buildMessageBundles([
+      makeNote(101, 1000, 'Windowed note'),
+      makeForward(201, 1000 + WINDOW_MS + 1, 'Late forward'),
+    ]);
+
+    expect(bundles).toHaveLength(2);
+    expect(bundles[0]).toMatchObject({
+      note_text: 'Windowed note',
+      forwarded_messages: [],
+      bundle_end_at: '1970-01-01T00:00:11.000Z',
+      status: 'normal',
+    });
+    expect(bundles[1]).toMatchObject({
+      note_text: '',
+      message_ids: [201],
+      status: 'ambiguous',
+      ambiguity_reason: 'orphan_forward',
+      forwarded_messages: [
+        expect.objectContaining({ message_id: 201, content: 'Late forward' }),
+      ],
+    });
+  });
+
+  test('marks both bundles ambiguous on timestamp conflict', () => {
+    const bundles = buildMessageBundles([
+      makeNote(101, 1000, 'Conflicting note'),
+      makeForward(201, 1000, 'Conflicting forward'),
+    ]);
+
+    expect(bundles).toHaveLength(2);
+    expect(bundles[0]).toMatchObject({
+      note_text: 'Conflicting note',
+      status: 'ambiguous',
+      ambiguity_reason: 'sequencing_conflict',
+    });
+    expect(bundles[1]).toMatchObject({
+      note_text: '',
+      status: 'ambiguous',
+      ambiguity_reason: 'timestamp_conflict',
+      message_ids: [201],
+    });
+  });
+
+  test('starts a new normal bundle when another note arrives', () => {
+    const bundles = buildMessageBundles([
+      makeNote(101, 1000, 'First note'),
+      makeForward(201, 1500, 'Forward from first note'),
+      makeNote(102, 5000, 'Second note'),
+    ]);
+
+    expect(bundles).toHaveLength(2);
+    expect(bundles.map((bundle) => bundle.note_text)).toEqual(['First note', 'Second note']);
+    expect(bundles.map((bundle) => bundle.status)).toEqual(['normal', 'normal']);
+  });
+});
+
+function makeForward(messageId, timestampMs, content) {
+  return {
+    type: 'forward',
+    messageId,
+    timestampMs,
+    content,
+    forwardMetadata: {
+      sourceInfo: '@source',
+      sourceUrl: 'https://t.me/source/1',
+      hasMedia: false,
+      mediaType: 'none',
+      forwardDate: '2025-01-01T00:00:00.000Z',
+      forwardProtected: false,
+    },
+  };
+}
+
+function makeNote(messageId, timestampMs, noteText) {
+  return {
+    type: 'note',
+    messageId,
+    timestampMs,
+    noteText,
+  };
+}
+
+function makeOther(messageId, timestampMs) {
+  return {
+    type: 'other',
+    messageId,
+    timestampMs,
+  };
+}


### PR DESCRIPTION
## Summary
- implement telegram message bundling (note + forwarded messages) with 10s window and ambiguity handling
- integrate bundling into telegram polling and persist bundle metadata/source URLs
- preserve bundle metadata through processing and restore duplicate detection for bundled source URLs
- add integration and unit coverage for bundling, source URL extraction, and polling edge cases

## Validation
- npm test
- npm test -- --coverage --collectCoverageFrom=scripts/poll-telegram.js --collectCoverageFrom=scripts/core/telegramMessageBundler.js --collectCoverageFrom=scripts/core/sourceUrls.js

Closes #28