### PR TITLE
migrate telegram sends to ci-shared transport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,16 +55,4 @@ jobs:
           CHAT_ID: ${{ secrets.CHAT_ID }}
           GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          # Use a heredoc to safely create the multiline string.
-          # Now, it references the simple shell variables defined in the 'env' block.
-          MESSAGE_TEXT=$(cat <<-EOF
-          🚨 *Build Failed:* [View Workflow Run](${GH_RUN_URL})
-          EOF
-          )
-
-          # URL-encode the message text to handle newlines and special characters correctly.
-          ENCODED_MESSAGE_TEXT=$(echo "$MESSAGE_TEXT" | awk -v ORS='%0A' '{ gsub(/&/, "\\&"); print }' | sed 's/ /%20/g')
-
-          # Send the message using curl and the Telegram Bot API.
-          # The '-s' flag makes curl silent (no progress meter).
-          curl -s -X POST "https://api.telegram.org/bot${BOT_TOKEN}/sendMessage" -d "chat_id=${CHAT_ID}" -d "text=${ENCODED_MESSAGE_TEXT}" -d "parse_mode=Markdown"
+          TELEGRAM_PARSE_MODE=Markdown ./scripts/ci/notify_telegram.sh "$BOT_TOKEN" "$CHAT_ID" "🚨 *Build Failed:* [View Workflow Run](${GH_RUN_URL})"

--- a/scripts/ci/notify_telegram.sh
+++ b/scripts/ci/notify_telegram.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec "$script_dir/../../vendor/ci-shared/scripts/notify_telegram.sh" "$@"

--- a/scripts/send-digest.js
+++ b/scripts/send-digest.js
@@ -1,3 +1,4 @@
+const { execFileSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
@@ -273,63 +274,34 @@ function getFileMetadata(file, cache) {
   }
 }
 
-async function sendTelegram(botToken, chatId, message) {
+function sendTelegram(botToken, chatId, message) {
   console.log('Sending message to Telegram...');
   console.log('Message preview:', message.substring(0, 200) + '...');
-  
-  const url = `https://api.telegram.org/bot${botToken}/sendMessage`;
-  
-  const params = new URLSearchParams({
-    chat_id: chatId,
-    text: message,
-    parse_mode: 'Markdown'
-  });
-  
-  try {
-    const response = await fetch(url, {
-      method: 'POST',
-      body: params,
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      }
-    });
-    
-    const result = await response.json();
-    
-    if (!response.ok || !result.ok) {
-      console.error('Telegram API error:', result);
-      
-      // Try without Markdown
-      console.log('Retrying without Markdown...');
-      const plainMessage = message
-        .replace(/\*/g, '')
-        .replace(/\\([_\[\]\(\)])/g, '$1');
 
-      const paramsNoMarkdown = new URLSearchParams({
-        chat_id: chatId,
-        text: plainMessage
+  const wrapper = path.join(__dirname, 'ci', 'notify_telegram.sh');
+
+  try {
+    execFileSync(wrapper, [botToken, chatId, message], {
+      env: { ...process.env, TELEGRAM_PARSE_MODE: 'Markdown' },
+      stdio: ['ignore', 'inherit', 'inherit'],
+    });
+  } catch (err) {
+    console.error('Telegram send failed:', err.message);
+    console.log('Retrying without Markdown...');
+    const plainMessage = message
+      .replace(/\*/g, '')
+      .replace(/\\([_\[\]\(\)])/g, '$1');
+
+    try {
+      execFileSync(wrapper, [botToken, chatId, plainMessage], {
+        stdio: ['ignore', 'inherit', 'inherit'],
       });
-      
-      const response2 = await fetch(url, {
-        method: 'POST',
-        body: paramsNoMarkdown,
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        }
-      });
-      
-      const result2 = await response2.json();
-      if (!result2.ok) {
-        throw new Error(`Telegram API failed: ${JSON.stringify(result2)}`);
-      }
+    } catch (retryErr) {
+      throw new Error(`Telegram send failed (retry without Markdown): ${retryErr.message}`);
     }
-    
-    console.log('Message sent successfully');
-    
-  } catch (error) {
-    console.error('Error sending to Telegram:', error);
-    throw error;
   }
+
+  console.log('Message sent successfully');
 }
 
 function getWeekNumber(date) {

--- a/vendor/ci-shared/scripts/notify_telegram.sh
+++ b/vendor/ci-shared/scripts/notify_telegram.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# vendored-from-repo: https://github.com/igor1309/ci-shared
+# vendored-from-path: scripts/notify_telegram.sh
+# vendored-from-commit: pre-emptive (ci-shared#4 in-flight)
+# vendored-on: 2026-03-01
+# Telegram transport: send one or more message chunks to a bot/chat.
+# Chunks are delivered sequentially in argument order. Fail-fast on
+# first error; partial delivery is accepted.
+#
+# Usage: notify_telegram.sh <token> <chat_id> <chunk1> [chunk2...]
+#
+# Environment:
+#   TELEGRAM_PARSE_MODE  – if set, adds parse_mode to API call
+#                          (Markdown | MarkdownV2 | HTML)
+#
+# Caller is responsible for message formatting, splitting, and
+# choosing which bot/chat to use.
+set -euo pipefail
+
+if [ "$#" -lt 3 ]; then
+  echo "usage: notify_telegram.sh <token> <chat_id> <chunk1> [chunk2...]" >&2
+  exit 2
+fi
+
+token="$1"
+chat_id="$2"
+shift 2
+
+parse_mode_args=()
+if [ -n "${TELEGRAM_PARSE_MODE:-}" ]; then
+  parse_mode_args=(--data-urlencode "parse_mode=${TELEGRAM_PARSE_MODE}")
+fi
+
+for chunk in "$@"; do
+  curl -fsS --connect-timeout 5 --max-time 20 \
+    --retry 3 --retry-delay 1 --retry-all-errors \
+    -X POST "https://api.telegram.org/bot${token}/sendMessage" \
+    -d "chat_id=${chat_id}" \
+    --data-urlencode "text=${chunk}" \
+    "${parse_mode_args[@]}"
+done


### PR DESCRIPTION
## Summary
- Vendor `notify_telegram.sh` from ci-shared with `TELEGRAM_PARSE_MODE` env var support (pre-emptive, ci-shared#4 in-flight)
- Add local wrapper `scripts/ci/notify_telegram.sh` (same delegation pattern as `scripts/run_silent.sh`)
- Migrate `send-digest.js` transport from custom `fetch()` to `execFileSync` wrapper call, preserving Markdown-to-plain fallback
- Replace inline curl in `ci.yml` with wrapper call

Closes #32

## Test plan
- [x] Existing tests pass (`npx jest` — 50/50)
- [x] Wrapper script runs and shows usage on no args (exit code 2)
- [ ] CI workflow triggers correctly on next push