### PR TITLE
ci: reduce runner costs (intake daily, digest weekly)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
   test-and-notify:
     name: Test and Notify
     runs-on: ubuntu-latest
+    # §2.0. Skip draft pull requests to avoid burning CI on WIP changes.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
 
     # §2.1. Permissions: Adheres to the principle of least privilege.
     permissions:

--- a/.github/workflows/digest-summary.yml
+++ b/.github/workflows/digest-summary.yml
@@ -2,16 +2,14 @@ name: Sentidex Digest
 
 on:
   schedule:
-    - cron: '0 4 * * 1-5'    # Workdays at 7:00 AM Moscow time
-    - cron: '0 4 * * 0,6'    # Weekends at 7:00 AM Moscow time
-    - cron: '0 17 * * *'     # Daily at 8:00 PM Moscow time
-  
+    - cron: '0 4 * * 0'    # Sunday at 7:00 AM Moscow time (UTC+3)
+
   workflow_dispatch:
     inputs:
       type:
         description: 'Digest type (daily or weekly)'
         required: true
-        default: 'daily'
+        default: 'weekly'
         type: choice
         options:
         - daily
@@ -26,13 +24,14 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Node.js
+      - name: Setup Node.js with npm cache
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
-        run: ./scripts/run_silent.sh "npm install" npm install
+        run: ./scripts/run_silent.sh "npm ci" npm ci
 
       - name: Generate and Send Digest
         env:
@@ -42,11 +41,9 @@ jobs:
           # Determine digest type based on the trigger
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             export DIGEST_TYPE="${{ inputs.type }}"
-          elif [ "${{ github.event.schedule }}" = "0 4 * * 0,6" ]; then
-            export DIGEST_TYPE="weekly"
           else
-            export DIGEST_TYPE="daily"
+            export DIGEST_TYPE="weekly"
           fi
-          
+
           echo "Running $DIGEST_TYPE digest..."
           ./scripts/run_silent.sh "send digest" node scripts/send-digest.js

--- a/.github/workflows/poll-and-process.yml
+++ b/.github/workflows/poll-and-process.yml
@@ -2,8 +2,8 @@ name: Sentidex Intake
 
 on:
   schedule:
-    # Run every 2 hours
-    - cron: "0 */2 * * *"
+    # Daily at 8:00 PM Moscow time (UTC+3)
+    - cron: "0 17 * * *"
 
   workflow_dispatch:
 
@@ -12,17 +12,109 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  poll:
-    uses: ./.github/workflows/telegram-polling.yml
-    secrets:
-      BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
-      CHAT_ID: ${{ secrets.CHAT_ID }}
+  poll-and-process:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
-  process:
-    needs: poll
-    uses: ./.github/workflows/process-messages.yml
-    with:
-      ai_provider: 'openai'
-    secrets:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      OPEN_ROUTER_GPT_OSS_20B_API_KEY: ${{ secrets.OPEN_ROUTER_GPT_OSS_20B_API_KEY }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js with npm cache
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        env:
+          NPM_CONFIG_AUDIT: "false"
+          NPM_CONFIG_FUND: "false"
+          NPM_CONFIG_PROGRESS: "false"
+        run: ./scripts/run_silent.sh "npm ci" npm ci
+
+      - name: Run Telegram polling
+        env:
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+          CHAT_ID: ${{ secrets.CHAT_ID }}
+        run: ./scripts/run_silent.sh "poll telegram" node scripts/poll-telegram.js
+
+      - name: Run message processing
+        env:
+          DEBUG: "true"
+          AI_PROVIDER: "openai"
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPEN_ROUTER_GPT_OSS_20B_API_KEY: ${{ secrets.OPEN_ROUTER_GPT_OSS_20B_API_KEY }}
+        run: ./scripts/run_silent.sh "process messages" node scripts/process-messages.js
+
+      - name: Commit and push changes
+        run: |
+          set -e
+          git config --local user.email "bot@sentidex.local"
+          git config --local user.name "Sentidex Bot"
+
+          if [ -d "inbox" ]; then
+            git add inbox/
+          fi
+          if [ -d "_inbox" ]; then
+            git add _inbox/
+          fi
+
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+
+          git commit -m "Intake: poll telegram + process messages"
+
+          if git push; then
+            echo "Pushed without rebasing"
+          else
+            echo "Initial push failed; attempting to rebase onto origin/trunk"
+            git fetch origin trunk
+
+            if git rebase origin/trunk; then
+              git push
+            else
+              echo "Rebase hit conflicts; attempting automated resolution for inbox files"
+              conflict_files=$(git diff --name-only --diff-filter=U)
+
+              if [ -z "$conflict_files" ]; then
+                echo "No conflicted files detected; aborting rebase"
+                git rebase --abort
+                exit 1
+              fi
+
+              unresolved=0
+
+              for file in $conflict_files; do
+                if [[ "$file" == inbox/* ]]; then
+                  git restore --theirs "$file"
+                  git add "$file"
+                elif [[ "$file" == _inbox/* ]]; then
+                  git restore --ours "$file"
+                  git add "$file"
+                else
+                  echo "Conflict in unexpected file: $file"
+                  unresolved=1
+                fi
+              done
+
+              if [ "$unresolved" -ne 0 ]; then
+                echo "Aborting rebase due to unresolved conflicts"
+                git rebase --abort
+                exit 1
+              fi
+
+              if git diff --staged --quiet; then
+                echo "No staged changes after conflict resolution; skipping empty commit"
+                git rebase --skip
+              else
+                GIT_EDITOR=true git rebase --continue
+              fi
+              git push
+            fi
+          fi

--- a/.github/workflows/process-messages.yml
+++ b/.github/workflows/process-messages.yml
@@ -39,11 +39,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: List files in workspace
-        run: |
-          set -e
-          ls -R
-
       - name: Setup Node.js with npm cache
         uses: actions/setup-node@v4
         with:

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,5 +1,9 @@
 # Log
 
+## 2026-04-26
+
+Cut CI runner costs: merge intake poll+process into one daily 8pm Moscow run (was 12×/day across 2 runners), reduce digest to weekly Sunday only with npm cache, drop `ls -R` debug step, skip CI on draft PRs.
+
 ## 2026-03-01
 
 - Migrate Telegram sends to ci-shared `notify_telegram.sh` transport. Replace fetch-based HTTP in `send-digest.js` with `execFileSync` to vendored wrapper. Replace inline curl in CI workflow with wrapper call.


### PR DESCRIPTION
## Summary
- Merge intake `poll` + `process` into one job and run once daily at 8pm Moscow (was 12×/day across 2 runners).
- Reduce digest to a single Sunday-morning weekly run; add `npm` cache and switch `npm install` → `npm ci`.
- Drop `ls -R` debug step from `process-messages.yml`.
- Skip `Continuous Integration` workflow on draft PRs.

`telegram-polling.yml` and `process-messages.yml` are kept in place for manual `workflow_dispatch`.

## Test plan
- [ ] Manually dispatch `Sentidex Intake` and verify poll → process → commit/push works in one runner.
- [ ] Manually dispatch `Sentidex Digest` and verify cache hit + `npm ci` succeeds.
- [ ] Open a draft PR and confirm `Continuous Integration` does not run; mark ready and confirm it runs.